### PR TITLE
Update smtp.php

### DIFF
--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -142,7 +142,7 @@ class Smtp {
 
 				$this->handleReply($handle, 220, 'Error: STARTTLS not accepted from server!');
 
-				stream_socket_enable_crypto($handle, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+				stream_socket_enable_crypto($handle, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
 			}
 
 			if (!empty($this->smtp_username) && !empty($this->smtp_password)) {


### PR DESCRIPTION
changed the crypto type passed to stream_socket_enable_crypto in case of TLS host. As the current option of "STREAM_CRYPTO_METHOD_TLS_CLIENT" defaults to TLS 1.0 after PHP 5.6 which in turns fails on many mail hosts. As TLS 1.0 is not recommended by many mail hosts.